### PR TITLE
fix Changesets release with pnpm devEngines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          # Allow Changesets' internal npm calls to warn on pnpm-only devEngines instead of failing the release.
+          NPM_CONFIG_FORCE: true
           NPM_TOKEN: ''


### PR DESCRIPTION
## Summary

- add `NPM_CONFIG_FORCE` only to the Changesets release step
- document why the release workflow needs npm to warn instead of fail on pnpm-only `devEngines`

## Why

`changeset publish` invokes npm internally for registry checks/publishing. npm evaluates `devEngines.packageManager` and fails when the repo requires pnpm, so the release job needs this narrowly scoped npm config.

## Validation

- reviewed the workflow diff
- no runtime tests run; workflow-only change
