### PR TITLE
fix(progress): clear checklist state in every mode

### DIFF
--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -3432,8 +3432,8 @@ describe('progress output', () => {
     assert.match(devcontainerSource, /spinnerLabel: 'Preparing container SSH runtime'/)
     assert.match(devcontainerSource, /spinnerLabel: 'Refreshing GitHub CLI auth inside the devcontainer'/)
     assert.match(devcontainerSource, /spinnerLabel: 'Verifying GitHub CLI auth inside the devcontainer'/)
-    assert.match(sshKeySource, /spinnerLabel: 'Generating Boxdown SSH identity'/)
-    assert.match(sshKeySource, /spinnerLabel: 'Writing Boxdown SSH public key'/)
+    assert.match(sshKeySource, /Generating Boxdown SSH identity/)
+    assert.match(sshKeySource, /Writing Boxdown SSH public key/)
   })
 
   test('verbose progress commands do not emit marker summaries', async () => {

--- a/docs/superpowers/plans/2026-07-11-progress-ci-regression.md
+++ b/docs/superpowers/plans/2026-07-11-progress-ci-regression.md
@@ -1,0 +1,125 @@
+# Progress CI Regression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore CI by making progress checklist cleanup mode-independent and updating stale spinner-label source assertions.
+
+**Architecture:** Preserve the existing `ProgressReporter` API and output behavior. Move only internal cleanup ahead of rendering guards, then loosen two source-presence assertions while leaving runtime checklist-output coverage intact.
+
+**Tech Stack:** TypeScript, Node.js 24 test runner, `node:assert`, pnpm, ESLint, tsdown
+
+## Global Constraints
+
+- Do not change progress APIs, spinner copy, output formatting, or command flow.
+- Use Node.js 24 for tests because the current Node.js 26 host runtime is incompatible with an installed CommonJS test dependency.
+- Commit documentation separately from the implementation, as explicitly requested.
+
+---
+
+### Task 1: Commit the approved documentation
+
+**Files:**
+
+- Create: `docs/superpowers/specs/2026-07-11-progress-ci-regression-design.md`
+- Create: `docs/superpowers/plans/2026-07-11-progress-ci-regression.md`
+
+**Interfaces:**
+
+- Consumes: The user-approved diagnosis and design.
+- Produces: Durable design and execution context for the CI fix.
+
+- [ ] **Step 1: Verify documentation formatting**
+
+Run:
+
+```bash
+git diff --check
+fnm exec --using v24.15.0 node ../../node_modules/markdownlint-cli/markdownlint.js \
+  -c .github/.markdownlint.yml -i 'apm_modules/**' -i '.git' -i '__tests__' \
+  -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' \
+  -i 'node_modules' -i 'dist' '**/**.md'
+```
+
+Expected: PASS with no whitespace or Markdown lint errors.
+
+- [ ] **Step 2: Commit documentation only**
+
+```bash
+git add docs/superpowers/specs/2026-07-11-progress-ci-regression-design.md docs/superpowers/plans/2026-07-11-progress-ci-regression.md
+git commit -m "docs: design progress CI regression fix"
+```
+
+Expected: A commit containing only the design specification and implementation plan.
+
+### Task 2: Fix progress cleanup and stale assertions
+
+**Files:**
+
+- Modify: `src/progress.ts:147`
+- Test: `__tests__/app.test.ts:3080`
+- Test: `__tests__/app.test.ts:3427`
+
+**Interfaces:**
+
+- Consumes: `ProgressReporter.end()` and `ProgressReporter.isChecklistActive()`.
+- Produces: Mode-independent reporter cleanup without API changes.
+
+- [ ] **Step 1: Verify the existing tests reproduce both CI failures**
+
+Run:
+
+```bash
+fnm exec --using v24.15.0 node --import tsx --test \
+  --test-name-pattern='reports whether a checklist is active|hidden command helpers use friendly spinner labels' \
+  __tests__/app.test.ts
+```
+
+Expected: FAIL because checklist state remains active in `none` mode and the SSH label regular expressions require an outdated direct-property expression.
+
+- [ ] **Step 2: Make cleanup independent of rendering mode**
+
+In `ProgressReporter.end()`, clear internal state immediately after stopping timers:
+
+```ts
+this.#steps = []
+this.#renderedStepLineCount = 0
+```
+
+Remove the existing duplicate cleanup after the interactive section terminator.
+
+- [ ] **Step 3: Make the source-presence assertions expression-shape independent**
+
+Replace the two SSH assertions with:
+
+```ts
+assert.match(sshKeySource, /Generating Boxdown SSH identity/)
+assert.match(sshKeySource, /Writing Boxdown SSH public key/)
+```
+
+- [ ] **Step 4: Verify the focused regression tests pass**
+
+Run the Step 1 command again.
+
+Expected: PASS for both selected tests.
+
+- [ ] **Step 5: Run full verification**
+
+Run:
+
+```bash
+fnm exec --using v24.15.0 node ../../node_modules/c8/bin/c8.js node --import tsx --test __tests__/**/*.test.ts
+fnm exec --using v24.15.0 node ../../node_modules/eslint/bin/eslint.js .
+fnm exec --using v24.15.0 node ../../node_modules/typescript/bin/tsc
+fnm exec --using v24.15.0 node ../../node_modules/tsdown/dist/run.mjs
+```
+
+Expected: All tests pass, ESLint reports no errors, TypeScript compilation succeeds, and tsdown builds successfully.
+
+- [ ] **Step 6: Commit the implementation separately**
+
+```bash
+git add src/progress.ts __tests__/app.test.ts
+git commit -m "fix(progress): clear checklist state in every mode"
+```
+
+Expected: A second commit containing only the production fix and updated assertions.

--- a/docs/superpowers/specs/2026-07-11-progress-ci-regression-design.md
+++ b/docs/superpowers/specs/2026-07-11-progress-ci-regression-design.md
@@ -1,0 +1,43 @@
+# Progress CI Regression Design
+
+## Goal
+
+Restore the test suite by fixing progress checklist cleanup in every output mode
+and updating stale spinner-label assertions without changing user-facing output.
+
+## Root Cause
+
+`ProgressReporter.end()` stops timers before checking the output mode, but it
+clears checklist state only after the interactive-only rendering guards. In
+`none` and `verbose` modes, `isChecklistActive()` therefore remains true after
+the reporter ends.
+
+The SSH spinner labels remain present and are used when no checklist is active.
+Their source expressions became conditional when checklist-owned output was
+introduced, so the source-text test's direct-property regular expressions no
+longer match them.
+
+## Design
+
+Move internal checklist cleanup ahead of the output-mode and section-rendering
+guards in `ProgressReporter.end()`. Ending a reporter will always clear its
+steps and rendered-line count, while only interactive reporters with an open
+section will write the visual terminator.
+
+Keep the existing source-presence test because it guards friendly spinner copy,
+but make the two SSH assertions check for the label text rather than requiring
+a particular property-expression shape. Existing runtime tests continue to
+verify that checklist mode suppresses the standalone spinners.
+
+## Scope
+
+- Modify `src/progress.ts` only to make state cleanup mode-independent.
+- Modify the two SSH label assertions in `__tests__/app.test.ts`.
+- Do not change progress APIs, spinner copy, output formatting, or command flow.
+
+## Verification
+
+Use the two CI failures as the red phase, then run the targeted progress tests,
+the full test suite, lint, and build. Verification must use a supported Node 24
+runtime because the current host Node 26 runtime is incompatible with one of
+the installed CommonJS test dependencies.

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -147,6 +147,8 @@ export class ProgressReporter {
   end (): void {
     this.stopSpinner()
     this.#stopStepTimer()
+    this.#steps = []
+    this.#renderedStepLineCount = 0
 
     if (this.mode !== 'interactive') {
       return
@@ -158,8 +160,6 @@ export class ProgressReporter {
 
     this.#write(this.target, formatPromptEnd())
     this.#sectionOpen = false
-    this.#steps = []
-    this.#renderedStepLineCount = 0
   }
 
   item (message: string): void {


### PR DESCRIPTION
## Summary

- clear progress checklist state whenever a reporter ends, including `none` and
  `verbose` output modes
- keep friendly SSH spinner-label coverage without coupling the test to a
  specific conditional expression shape
- document the diagnosis, design, and verification plan in a separate commit

## Root cause

`ProgressReporter.end()` returned before clearing its checklist state outside
interactive mode. As a result, `isChecklistActive()` incorrectly remained true
after the reporter ended. A second test asserted an outdated direct-property
source shape after the SSH spinner labels became conditional.

## Impact

Reporter lifecycle state is now consistent across output modes. User-facing
progress copy and rendering behavior are unchanged.

## Validation

- Node.js 24 focused regression tests: 2 passed, 0 failed
- Node.js 24 full test suite: 173 passed, 0 failed
- ESLint: passed
- Markdown lint: passed
- TypeScript: passed
- tsdown CJS and ESM builds: passed

Fixes the failures observed in
https://github.com/lirantal/boxdown/actions/runs/29142367492.
