### PR TITLE
feat: sign commits in Boxdown environments

### DIFF
--- a/.changeset/signed-boxdown-commits.md
+++ b/.changeset/signed-boxdown-commits.md
@@ -1,0 +1,5 @@
+---
+"boxdown": minor
+---
+
+Enable best-effort SSH commit signing in new Boxdown environments.

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ typings/
 
 # Snyk
 .dccache
+
+# Local git worktrees
+.worktrees/

--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -16,6 +16,7 @@ import { BOXDOWN_CONTAINER_AGENTS_DIR, BOXDOWN_CONTAINER_CODEX_AUTH_PATH, BOXDOW
 import { codingAgentDevcontainerExecArgs, sshTunnelArgs } from '../src/devcontainer.ts'
 import { resolveDevcontainerCli } from '../src/devcontainer-cli.ts'
 import { doctorHasFailures, formatDoctorText, runDoctorChecks } from '../src/doctor.ts'
+import { parseSshPublicKey, selectGitSigningKey, type GitSigningPlan } from '../src/git-signing.ts'
 import { canonicalGithubRemoteUrl, configureWorkspaceGithubGitAuth } from '../src/github-git-auth.ts'
 import { parseJsonc } from '../src/jsonc.ts'
 import { createWorkspaceListEntries, formatWorkspaceListDetailsText, formatWorkspaceListText } from '../src/list.ts'
@@ -2839,12 +2840,21 @@ describe('doctor output', () => {
       includeDockerMountProbe: false,
       runCommand: async (command, args) => {
         calls.push(`${command} ${args.join(' ')}`)
-        return { code: 0, stdout: '', stderr: '' }
+        return command === 'ssh-add'
+          ? { code: 0, stdout: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest doctor\n', stderr: '' }
+          : command === 'gh' && args.includes('user/ssh_signing_keys')
+            ? { code: 0, stdout: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest\n', stderr: '' }
+            : command === 'gh' && args.includes('user')
+              ? { code: 0, stdout: 'example\n', stderr: '' }
+              : command === 'gh' && args.includes('users/example/ssh_signing_keys')
+                ? { code: 0, stdout: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest\n', stderr: '' }
+          : { code: 0, stdout: '', stderr: '' }
       }
     })
 
     assert.ok(checks.every((item) => item.name !== 'gh' && item.name !== 'gh-auth'))
     assert.ok(calls.every((call) => !call.startsWith('gh ')))
+    assert.ok(checks.some((item) => item.name === 'git-signing-agent'))
     assert.ok(checks.every((item) => item.level === 'ok'))
   })
 
@@ -3561,6 +3571,24 @@ describe('progress output', () => {
 })
 
 describe('devcontainer config generation', () => {
+  test('adds an SSH-agent and public-key mount for an enabled signing plan', () => {
+    const context = createWorkspaceContext({
+      workspace: tempDir('git-signing-config-workspace'),
+      env: { BOXDOWN_CACHE_HOME: tempDir('git-signing-config-cache'), BOXDOWN_DATA_HOME: tempDir('git-signing-config-data') },
+      assetsDevcontainerDir
+    })
+    const signing: GitSigningPlan = {
+      enabled: true,
+      publicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKey comment',
+      agentSocketSource: '/run/host-services/ssh-auth.sock'
+    }
+
+    const config = buildGeneratedDevcontainerConfig(context, signing)
+
+    assert.ok(config.mounts?.includes(`type=bind,source=${signing.agentSocketSource},target=/run/boxdown/ssh-agent.sock`))
+    assert.ok(config.mounts?.includes(`type=bind,source=${context.gitSigningStateDir},target=/opt/boxdown/state/git-signing,readonly`))
+    assert.strictEqual(config.containerEnv?.SSH_AUTH_SOCK, '/run/boxdown/ssh-agent.sock')
+  })
   test('rewrites lifecycle paths to Boxdown assets and mounted runtime', () => {
     const workspace = tempDir('config-workspace')
     const context = createWorkspaceContext({
@@ -3675,6 +3703,24 @@ describe('devcontainer config generation', () => {
   })
 })
 
+describe('git signing selection', () => {
+  const first = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFirstKey first@example.com'
+  const second = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKey second@example.com'
+
+  test('normalizes public keys without comments', () => {
+    assert.strictEqual(parseSshPublicKey(first), 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFirstKey')
+  })
+
+  test('selects a configured loaded key', () => {
+    assert.deepStrictEqual(selectGitSigningKey([first, second], second), { key: parseSshPublicKey(second) })
+  })
+
+  test('selects one GitHub identity but does not guess between ambiguous keys', () => {
+    assert.deepStrictEqual(selectGitSigningKey([first, second], undefined, [second]), { key: parseSshPublicKey(second) })
+    assert.deepStrictEqual(selectGitSigningKey([first, second]), { reason: 'ambiguous-identities' })
+  })
+})
+
 describe('devcontainer git config hooks', () => {
   test('initialize snapshots host gitconfig and removes stale snapshot when host file is absent', () => {
     const initializePath = join(assetsDevcontainerDir, 'hooks', 'initialize.sh')
@@ -3743,8 +3789,8 @@ describe('devcontainer git config hooks', () => {
     assert.strictEqual(readGitConfig(targetPath, 'url.ssh://git@github.com/.insteadOf'), undefined)
     assert.deepStrictEqual(readGitConfigAll(targetPath, 'credential.helper'), ['cache'])
     assert.deepStrictEqual(readGitConfigAll(targetPath, 'credential.https://github.com.helper'), ['', '!gh auth git-credential'])
-    assert.strictEqual(readGitConfig(targetPath, 'commit.gpgsign'), 'false')
-    assert.strictEqual(readGitConfig(targetPath, 'tag.gpgsign'), 'false')
+    assert.strictEqual(readGitConfig(targetPath, 'commit.gpgsign'), 'true')
+    assert.strictEqual(readGitConfig(targetPath, 'tag.gpgsign'), 'true')
   })
 
   test('git config bootstrap succeeds without a host snapshot', () => {
@@ -3779,8 +3825,21 @@ describe('devcontainer git config hooks', () => {
       .split(/\r?\n/)
 
     assert.deepStrictEqual(helpers, ['', '!gh auth git-credential'])
-    assert.strictEqual(execFileSync('git', ['config', '--local', '--get', 'commit.gpgsign'], { cwd: workspace }).toString('utf8').trim(), 'false')
+    assert.strictEqual(readGitConfig(join(workspace, '.git', 'config'), 'commit.gpgsign'), undefined)
     assert.strictEqual(execFileSync('git', ['config', '--local', '--get', 'core.pager'], { cwd: workspace }).toString('utf8').trim(), 'less -R')
+  })
+
+  test('git signing bootstrap falls back to unsigned commits without an agent', () => {
+    const bootstrapPath = join(assetsDevcontainerDir, 'utils', 'git-signing-bootstrap.sh')
+    const targetPath = join(tempDir('git-signing-target'), '.gitconfig')
+    writeFileSync(targetPath, '[gpg]\n\tprogram = /opt/homebrew/bin/gpg\n[commit]\n\tgpgsign = true\n')
+
+    execFileSync('bash', [bootstrapPath], {
+      env: { ...process.env, BOXDOWN_GITCONFIG_TARGET_PATH: targetPath, BOXDOWN_GIT_SIGNING_ENABLED: '0' }
+    })
+
+    assert.strictEqual(readGitConfig(targetPath, 'commit.gpgsign'), 'false')
+    assert.strictEqual(readGitConfig(targetPath, 'gpg.program'), undefined)
   })
 })
 

--- a/assets/devcontainer/hooks/post-create.sh
+++ b/assets/devcontainer/hooks/post-create.sh
@@ -6,6 +6,7 @@ DEVCONTAINER_DIR="$(cd "${HOOKS_DIR}/.." && pwd)"
 
 main() {
   run_step "Configuring global Git" configure_global_git
+  run_step "Configuring Git commit signing" configure_git_signing
   run_step "Configuring workspace Git" configure_local_git
   run_step "Installing OpenSSH server" install_openssh_server
   run_step "Installing Python runtime" install_python_runtime
@@ -34,10 +35,13 @@ configure_global_git() {
   bash "${DEVCONTAINER_DIR}/utils/git-config-bootstrap.sh"
 }
 
+configure_git_signing() {
+  bash "${DEVCONTAINER_DIR}/utils/git-signing-bootstrap.sh"
+}
+
 configure_local_git() {
   # Local git prefs only apply inside a repository; skip when there is no .git (avoids postCreate failure).
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git config --local --replace-all commit.gpgsign false
     git config --local --replace-all core.pager 'less -R'
     git config --local --unset-all credential.https://github.com.helper >/dev/null 2>&1 || true
     git config --local --add credential.https://github.com.helper ''

--- a/assets/devcontainer/hooks/post-start.sh
+++ b/assets/devcontainer/hooks/post-start.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # post-start: runs after each container start (postStartCommand in devcontainer.json).
-# Naming matches post-create.sh; extend with more steps as needed (e.g. source scripts from .devcontainer/utils/).
+set -euo pipefail
+
+DEVCONTAINER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bash "${DEVCONTAINER_DIR}/utils/git-signing-bootstrap.sh"
 
 set -euo pipefail
 

--- a/assets/devcontainer/utils/git-config-bootstrap.sh
+++ b/assets/devcontainer/utils/git-config-bootstrap.sh
@@ -17,7 +17,6 @@ main() {
   sanitize_host_credential_helpers credential.helper
   sanitize_host_credential_helpers credential.https://github.com.helper
   configure_container_github_auth
-  disable_container_git_signing
 }
 
 progress() {
@@ -124,11 +123,6 @@ configure_container_github_auth() {
   git_global --unset-all credential.https://github.com.helper >/dev/null 2>&1 || true
   git_global --add credential.https://github.com.helper ''
   git_global --add credential.https://github.com.helper '!gh auth git-credential'
-}
-
-disable_container_git_signing() {
-  git_global --replace-all commit.gpgsign false
-  git_global --replace-all tag.gpgsign false
 }
 
 main "$@"

--- a/assets/devcontainer/utils/git-signing-bootstrap.sh
+++ b/assets/devcontainer/utils/git-signing-bootstrap.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Configure best-effort SSH commit signing without modifying the workspace Git config.
+
+set -euo pipefail
+
+TARGET_PATH="${BOXDOWN_GITCONFIG_TARGET_PATH:-/home/node/.gitconfig}"
+KEY_PATH="${BOXDOWN_GIT_SIGNING_KEY_PATH:-/opt/boxdown/state/git-signing/signing-key.pub}"
+ENABLED="${BOXDOWN_GIT_SIGNING_ENABLED:-0}"
+
+git_global() {
+  GIT_CONFIG_GLOBAL="${TARGET_PATH}" git config --global "$@"
+}
+
+disable_signing() {
+  git_global --unset-all gpg.format >/dev/null 2>&1 || true
+  git_global --unset-all user.signingkey >/dev/null 2>&1 || true
+  git_global --unset-all gpg.program >/dev/null 2>&1 || true
+  git_global --replace-all commit.gpgsign false
+  printf '%s\n' 'boxdown: commit signing unavailable; commits will remain unsigned.' >&2
+}
+
+enable_signing() {
+  if [[ ! -r "${KEY_PATH}" ]] || ! ssh-add -L | grep -qF "$(awk 'NR == 1 { print $1 " " $2 }' "${KEY_PATH}")"; then
+    disable_signing
+    return 0
+  fi
+
+  git_global --unset-all gpg.program >/dev/null 2>&1 || true
+  git_global --replace-all gpg.format ssh
+  git_global --replace-all user.signingkey "${KEY_PATH}"
+  git_global --replace-all commit.gpgsign true
+
+  local probe_dir
+  probe_dir="$(mktemp -d)"
+  if ! (
+    cd "${probe_dir}"
+    git init -q
+    git config user.name 'Boxdown signing probe'
+    git config user.email 'signing-probe@boxdown.invalid'
+    git config gpg.format ssh
+    git config user.signingkey "${KEY_PATH}"
+    git config commit.gpgsign true
+    git commit --allow-empty -m 'boxdown signing probe' >/dev/null
+  ); then
+    rm -rf "${probe_dir}"
+    disable_signing
+    return 0
+  fi
+  rm -rf "${probe_dir}"
+}
+
+if [[ "${ENABLED}" == "1" ]]; then
+  enable_signing
+else
+  disable_signing
+fi

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -9,6 +9,7 @@ flows behind them.
 - [SSH config and proxy workflow](./ssh-config-and-proxy.md)
 - [GitHub auth refresh](./github-auth-refresh.md)
 - [Generated config and state](./generated-config-and-state.md)
+- [Commit signing](./commit-signing.md)
 
 Most features share the same first step: resolve a target workspace, derive
 workspace-specific state paths, generate a devcontainer override config, and

--- a/docs/features/commit-signing.md
+++ b/docs/features/commit-signing.md
@@ -1,0 +1,23 @@
+# Commit signing
+
+New Boxdown environments attempt SSH commit signing by default. Boxdown forwards
+the host SSH agent, selects a signing identity only when there is one
+unambiguous candidate, and keeps the private key on the host.
+
+If the agent is unavailable, has no identities, or has multiple identities
+that Boxdown cannot distinguish, Boxdown warns and configures unsigned commits.
+It never guesses a key and does not block setup or commits.
+
+The container can request operations from identities exposed by the forwarded
+agent. Use a dedicated signing identity or an agent that confirms sensitive
+operations when that exposure is unacceptable.
+
+GitHub verification is separate from signing. Upload the selected public key as
+a GitHub SSH signing key once to receive the Verified badge:
+
+```bash
+gh ssh-key add /path/to/signing-key.pub --type signing --title "Boxdown commit signing"
+```
+
+The same key may already be registered for GitHub SSH authentication; GitHub
+requires a second registration with type `signing`.

--- a/docs/superpowers/plans/2026-07-11-default-commit-signing.md
+++ b/docs/superpowers/plans/2026-07-11-default-commit-signing.md
@@ -1,0 +1,110 @@
+# Default Commit Signing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make new Boxdown environments sign commits through the host SSH agent by default, while retaining an unsigned, warning-only fallback.
+
+**Architecture:** A host-side resolver selects one unambiguous public SSH key and snapshots only that key into workspace state. The generated devcontainer config mounts the host agent and the public-key snapshot. A container bootstrap validates a disposable SSH-signed commit and configures global Git for SSH signing or disables it without touching repository-local Git config.
+
+**Tech Stack:** Node.js 24, TypeScript, Bash, Git, OpenSSH, Docker/Dev Containers CLI, Node test runner.
+
+## Global Constraints
+
+- Never copy private signing-key material into Boxdown state or the container.
+- Multiple ambiguous agent identities disable signing and warn; never select one arbitrarily.
+- Signing diagnostics are `warn`, never a setup-preflight failure.
+- Never write `commit.gpgsign` in the repository-local `.git/config`.
+- Docker integration is optional and must not pull images or push commits.
+
+---
+
+### Task 1: Resolve and persist a signing plan
+
+**Files:**
+
+- Create: `src/git-signing.ts`
+- Modify: `src/constants.ts`, `src/paths.ts`, `src/config.ts`
+- Test: `__tests__/app.test.ts`
+
+**Interfaces:**
+
+```ts
+export type GitSigningReason = 'agent-unavailable' | 'no-identities' | 'ambiguous-identities' | 'configured-key-not-loaded' | 'agent-mount-unavailable'
+export interface GitSigningPlan { enabled: boolean, reason?: GitSigningReason, publicKey?: string, agentSocketSource?: string }
+export function parseSshPublicKey(value: string): string | undefined
+export function selectGitSigningKey(identities: string[], configuredKey?: string, githubKeys?: string[]): { key?: string, reason?: GitSigningReason }
+export function writeGitSigningPublicKey(context: WorkspaceContext, key: string): void
+```
+
+- [ ] Write focused failing tests for parsing keys without comments, configured-key selection, a unique GitHub-key match, single-key fallback, ambiguous fallback, and config mount generation.
+- [ ] Run `node --import tsx --test --test-name-pattern='git signing|devcontainer config generation' __tests__/app.test.ts` and confirm the new assertions fail because the module and mounts do not exist.
+- [ ] Add state paths and container constants, implement the pure resolver and public-key snapshot, and let `buildGeneratedDevcontainerConfig(context, signingPlan)` add read-only key-state and agent mounts only for enabled plans.
+- [ ] Rerun the focused tests and confirm they pass.
+
+### Task 2: Configure and validate container-side Git signing
+
+**Files:**
+
+- Create: `assets/devcontainer/utils/git-signing-bootstrap.sh`
+- Modify: `assets/devcontainer/utils/git-config-bootstrap.sh`, `assets/devcontainer/hooks/post-create.sh`, `assets/devcontainer/hooks/post-start.sh`
+- Test: `__tests__/app.test.ts`
+
+**Interfaces:**
+
+```bash
+bash /opt/boxdown/devcontainer/utils/git-signing-bootstrap.sh
+# Reads BOXDOWN_GIT_SIGNING_ENABLED and BOXDOWN_GIT_SIGNING_KEY_PATH.
+# Exits 0 in both signed and unsigned fallback modes.
+```
+
+- [ ] Write failing shell-hook tests for successful SSH configuration, absent-agent fallback, removal of incompatible `gpg.program`, and absence of repository-local `commit.gpgsign` writes.
+- [ ] Run the matching `devcontainer git config hooks` tests and confirm the new assertions fail.
+- [ ] Implement a temporary-repository signing probe using `ssh-add -L`, a temporary allowed-signers file, and `git commit --allow-empty`; set global SSH signing only after it succeeds, otherwise set global `commit.gpgsign=false` and print a warning.
+- [ ] Remove unconditional global signing disablement and all post-create local `commit.gpgsign` mutations; call the bootstrap after create and start.
+- [ ] Rerun the hook tests and confirm they pass.
+
+### Task 3: Use one signing-aware lifecycle for every command
+
+**Files:**
+
+- Modify: `src/devcontainer.ts`, `src/main.ts`
+- Test: `__tests__/app.test.ts`
+
+**Interfaces:**
+
+```ts
+export async function resolveGitSigningPlan(context: WorkspaceContext): Promise<GitSigningPlan>
+export async function ensureContainerGitSigning(context: WorkspaceContext, plan: GitSigningPlan, options?: ContainerCommandOptions): Promise<void>
+```
+
+- [ ] Write failing command-flow tests proving `startDevcontainer` writes a signing-aware config and invokes the non-fatal container signing refresh for fresh and reused containers.
+- [ ] Run the relevant `CLI execution` and `coding-agent command mapping` tests and confirm they fail on the missing signing lifecycle.
+- [ ] Resolve the plan before writing generated config, pass plan state to the lifecycle script, and call the refresh from shared startup so setup, shell, coding agents, SSH proxy, and tunnels all inherit it.
+- [ ] Ensure refresh failures only warn and do not change the command exit code.
+- [ ] Rerun focused lifecycle tests and confirm they pass.
+
+### Task 4: Add doctor/preflight warnings and user documentation
+
+**Files:**
+
+- Modify: `src/doctor.ts`, `src/main.ts`, `README.md`, `docs/features/setup.md`, `docs/architecture.md`, `docs/features/README.md`
+- Create: `docs/features/commit-signing.md`, `.changeset/<generated-name>.md`
+- Test: `__tests__/app.test.ts`
+
+- [ ] Write failing doctor tests for unavailable agent, ambiguous identities, unusable mount, missing GitHub signing registration, and warning-only setup behavior.
+- [ ] Run the `doctor output` and setup-preflight tests and confirm the new checks are absent.
+- [ ] Add warning-only host signing checks, including an optional GitHub signing-key query; do not add account mutations or required preflight failures.
+- [ ] Document automatic selection order, unsigned fallback, Docker mount limitations, agent security exposure, and GitHub's one-time separate signing-key registration.
+- [ ] Add a changeset for default-on best-effort commit signing.
+- [ ] Rerun focused doctor/setup tests and lint changed Markdown.
+
+### Task 5: Verify the full feature
+
+**Files:**
+
+- Test: `__tests__/app.test.ts`
+
+- [ ] Run `node --import tsx --test __tests__/**/*.test.ts`; record the two known unrelated baseline failures and require no additional failures.
+- [ ] Run `npm run build` and `npm run lint` using local project tooling where available.
+- [ ] With Docker and a loaded agent available, create a disposable container using the generated mount, make an empty signed commit, and verify its SSH fingerprint; do not push it.
+- [ ] Review `git diff --check`, changed docs, and the implementation against `docs/superpowers/specs/2026-07-11-default-commit-signing-design.md`.

--- a/docs/superpowers/specs/2026-07-11-default-commit-signing-design.md
+++ b/docs/superpowers/specs/2026-07-11-default-commit-signing-design.md
@@ -1,0 +1,396 @@
+# Default Commit Signing Design
+
+## Summary
+
+Boxdown will attempt to enable SSH commit signing by default in every newly
+created environment. It will forward the host SSH agent into the container,
+select a signing identity without user interaction when that choice is
+unambiguous, and configure container-global Git settings for SSH signing.
+
+Signing is best-effort. If Boxdown cannot select or use a signing identity, it
+will warn, disable signing in the container-global Git configuration, and allow
+unsigned commits. Signing readiness will never make `boxdown setup` fail.
+
+This design applies only to newly created Boxdown environments. It does not
+migrate existing containers or repair repository-local Git settings written by
+older Boxdown versions.
+
+## Goals
+
+- Sign commits by default without a separate Boxdown signing setup command.
+- Keep private signing keys on the host and expose only an agent-backed signing
+  capability to the container.
+- Provide the same signing capability through `boxdown setup`, `start`,
+  `codex`, `claude`, `opencode`, `antigravity`, SSH proxy, and tunnel flows.
+- Continue allowing commits when signing cannot be configured or validated.
+- Detect signing problems in `boxdown doctor` and the setup preflight without
+  making signing readiness a setup prerequisite.
+- Explain the difference between a cryptographically signed commit and a
+  commit that GitHub displays as Verified.
+
+## Non-goals
+
+- Migrating existing Boxdown environments or legacy `.git/config` values.
+- Copying a private GPG or SSH key into a container or Boxdown state.
+- Automatically changing the user's GitHub account or registering signing
+  keys without explicit user action.
+- Guaranteeing that a host agent remains available after an interactive
+  session has started.
+- Intercepting `git commit` and automatically retrying it with
+  `--no-gpg-sign`.
+
+## Approaches Considered
+
+### SSH signing through the Docker agent bridge
+
+This is the selected approach. Docker Desktop exposes the host SSH agent to a
+container through `/run/host-services/ssh-auth.sock`, while native Linux Docker
+can bind-mount the host path in `SSH_AUTH_SOCK`. Git supports signing through
+that agent with `gpg.format=ssh`.
+
+This approach works for both SSH sessions and Boxdown's primary
+`devcontainer exec` execution path. It does not copy private key material.
+
+### GPG-agent forwarding over SSH
+
+GPG-agent forwarding was validated successfully, but the forwarded socket
+exists only during an SSH connection. Boxdown launches shells and coding-agent
+CLIs through `devcontainer exec`, so GPG forwarding would require an additional
+long-lived host proxy and remote socket lifecycle management. It is not the
+default design.
+
+### Container-owned signing key
+
+A key persisted in Boxdown state would remain available independently of the
+host agent, but the container could read and copy the private key. Every new
+key would also require GitHub registration. This weakens Boxdown's isolation
+boundary and is rejected.
+
+## Signing Policy
+
+Signing is default-on but best-effort:
+
+1. Boxdown attempts to resolve one host SSH signing identity.
+2. Boxdown attempts to expose the host agent to the container.
+3. The container verifies that the selected identity is loaded and can create
+   a disposable signed commit.
+4. If all checks pass, container-global `commit.gpgsign` is set to `true`.
+5. If any check fails, container-global `commit.gpgsign` is set to `false` and
+   Boxdown reports a warning.
+
+Boxdown must never select the first of multiple ambiguous candidates. If it
+cannot identify exactly one intended key, signing is disabled and commits
+continue unsigned. This behavior must be documented in the README, signing
+feature documentation, `boxdown doctor` output, and setup warnings.
+
+Boxdown will no longer write `commit.gpgsign` into the repository-local
+`.git/config`. Repository-local configuration is shared with the host and is
+not container-owned state.
+
+An explicit repository-local `commit.gpgsign=true` remains the user's policy
+and can override Boxdown's container-global fallback. Boxdown does not rewrite
+explicit repository policy to guarantee unsigned fallback.
+
+## Host Signing Resolution
+
+A new host-side module will produce a typed signing plan before generated
+devcontainer configuration is written. The plan records whether signing is
+enabled, the selected public key, its fingerprint, the agent mount source, and
+a stable reason when signing is unavailable.
+
+Public keys are compared by algorithm and base64 key data. Comments are not
+part of identity matching.
+
+Boxdown resolves a signing identity in this order:
+
+1. If the host Git configuration uses `gpg.format=ssh`, resolve its
+   `user.signingKey`. Select it only if the corresponding public key is loaded
+   in the host agent.
+2. Otherwise, when authenticated GitHub CLI access and the network are
+   available, intersect the loaded agent identities with the current GitHub
+   user's SSH authentication keys. Select the key only when exactly one loaded
+   identity matches.
+3. Otherwise, select the loaded identity only when the agent contains exactly
+   one identity.
+4. With zero or multiple unresolved identities, produce a disabled signing
+   plan and a warning reason. Do not guess.
+
+Failure to execute `ssh-add`, query GitHub, parse a public key, or resolve a
+single identity is non-fatal.
+
+The selected public key is written outside the repository under:
+
+```text
+~/.local/share/boxdown/workspaces/<workspace-id>/git-signing/signing-key.pub
+```
+
+The signing state directory contains public material only. It is mounted
+read-only at `/opt/boxdown/state/git-signing`.
+
+## Agent Socket Resolution
+
+The generated configuration uses the fixed container path:
+
+```text
+/run/boxdown/ssh-agent.sock
+```
+
+and sets:
+
+```text
+SSH_AUTH_SOCK=/run/boxdown/ssh-agent.sock
+```
+
+On Docker Desktop for macOS and Linux, the mount source is Docker Desktop's
+host-service socket:
+
+```text
+/run/host-services/ssh-auth.sock
+```
+
+On native Linux Docker, the source is the host value of `SSH_AUTH_SOCK`.
+
+Boxdown probes a candidate source through Docker before adding it to generated
+configuration. If the probe fails, the mount and `SSH_AUTH_SOCK` container
+environment value are omitted and the signing plan is disabled. This prevents
+an unavailable bind source from blocking container creation.
+
+Because mounts are create-time state, an environment created while the agent
+bridge is unavailable remains unsigned until it is recreated. Boxdown warns
+about this limitation; it does not mutate existing container mounts.
+
+## Generated Devcontainer Configuration
+
+When signing is enabled, the generated configuration includes mounts
+equivalent to:
+
+```json
+{
+  "mounts": [
+    "type=bind,source=/run/host-services/ssh-auth.sock,target=/run/boxdown/ssh-agent.sock",
+    "type=bind,source=<workspace-signing-state>,target=/opt/boxdown/state/git-signing,readonly"
+  ],
+  "containerEnv": {
+    "SSH_AUTH_SOCK": "/run/boxdown/ssh-agent.sock"
+  }
+}
+```
+
+Native Linux substitutes the resolved host agent socket for the first source.
+The signing mount and environment value are absent from a disabled plan.
+
+Generated configuration accepts the resolved signing plan as input rather
+than discovering host or Docker state inside the pure configuration builder.
+This keeps mount generation deterministic and unit-testable.
+
+## Container Git Configuration
+
+Container Git bootstrap will stop unconditionally disabling commit signing.
+When the selected identity and socket validate, it will configure the writable
+container-global Git configuration with:
+
+```ini
+[gpg]
+    format = ssh
+[user]
+    signingKey = /opt/boxdown/state/git-signing/signing-key.pub
+[commit]
+    gpgSign = true
+```
+
+The bootstrap removes incompatible copied host settings such as
+`gpg.program=/opt/homebrew/bin/gpg`. It does not need a global
+`gpg.ssh.allowedSignersFile` to create signatures. A disposable repository may
+use a temporary allowed-signers file when validating its own signature.
+
+When validation fails, the container-global configuration uses:
+
+```ini
+[commit]
+    gpgSign = false
+```
+
+and removes Boxdown-owned SSH signing values that would otherwise leave an
+inconsistent configuration.
+
+Tag-signing behavior is not changed beyond removing the current unconditional
+`tag.gpgsign=false`. When a copied host configuration explicitly enables tag
+signing, the selected SSH signing configuration can satisfy it. Commit signing
+is the feature guaranteed by this design.
+
+## Lifecycle Consistency
+
+The Docker agent mount makes the host agent available to all container
+processes. It therefore covers both SSH access and the `devcontainer exec`
+path used by `boxdown start` and coding-agent commands.
+
+A focused container script owns signing configuration and validation. A shared
+`ensureContainerGitSigning` lifecycle helper invokes it after a container is
+started or reused and before control is handed to a shell, coding agent, SSH
+proxy, tunnel, or setup completion.
+
+All entry points use the same sequence:
+
+1. Resolve the host signing plan.
+2. Write signing-aware generated configuration.
+3. Start or reuse the container.
+4. Refresh container signing readiness.
+5. Continue normally whether signing is enabled or disabled.
+
+The signing refresh performs a disposable signed-commit test. A failed test
+changes the container-global fallback to unsigned and reports a warning. The
+test does not write to the user's repository.
+
+If the host agent or selected key disappears after an interactive process has
+started, a later `git commit` can still fail. Boxdown will document this narrow
+runtime limitation instead of replacing or wrapping the Git executable.
+
+## Doctor and Setup Preflight
+
+Signing readiness is optional. Every signing-related doctor result has `pass`
+or `warn` severity and never contributes a required setup failure.
+
+Host and preliminary checks cover:
+
+1. The host SSH agent can be queried.
+2. A signing identity can be selected unambiguously.
+3. Docker can expose the candidate agent socket to a container.
+4. When GitHub CLI and the network are available, the selected key is
+   registered as a GitHub SSH signing key.
+
+Container checks cover:
+
+1. `SSH_AUTH_SOCK` is reachable.
+2. The selected public key is present in `ssh-add -L`.
+3. A disposable Git repository can create a signed commit.
+4. The disposable commit contains a valid SSH signature from the selected
+   fingerprint.
+
+`boxdown setup` runs relevant host checks during its existing preliminary
+doctor stage and prints warnings before container creation. After the
+container starts, the shared signing refresh supplies the full container
+validation.
+
+`boxdown doctor` runs the host checks on every invocation. It runs full
+container validation in an existing Boxdown container. When no Boxdown
+container exists, it may use an already available local Boxdown image for a
+disposable probe; it does not pull an image solely for signing diagnostics.
+If a full probe is unavailable, doctor reports that limitation as a warning.
+
+## GitHub Verification
+
+A commit is cryptographically signed when Git creates and validates its SSH
+signature. GitHub displays that commit as Verified only when the corresponding
+public key is registered in the user's GitHub account as an SSH signing key.
+
+GitHub treats authentication and signing registrations separately. A public
+key already registered for SSH authentication must be uploaded a second time
+with type `signing`.
+
+Boxdown checks the selected key against `user/ssh_signing_keys` when possible.
+If it is absent, Boxdown keeps local signing enabled and warns that GitHub will
+not display Verified until the user completes the one-time registration. The
+warning includes an actionable command such as:
+
+```bash
+gh ssh-key add <public-key-file> --type signing --title "Boxdown commit signing"
+```
+
+Boxdown does not execute this account mutation automatically. GitHub or
+network unavailability never disables a locally usable signing identity after
+that identity has already been selected.
+
+## Security Model
+
+The agent bridge does not expose private key bytes, but any process in the
+container that can access the socket can request operations from every identity
+exposed by that host agent. Enabling signing therefore grants the container a
+signing oracle and potentially SSH authentication capability for the lifetime
+of the mount.
+
+Documentation will recommend a dedicated signing identity or an agent that
+requires confirmation for sensitive keys. The capability is default-on by
+product decision, but doctor output and security documentation must describe
+the exposure accurately.
+
+## Error Reporting
+
+Signing warnings use stable reasons so CLI and JSON doctor output remain
+testable. At minimum, reasons distinguish:
+
+- host agent unavailable;
+- no loaded identities;
+- ambiguous loaded identities;
+- configured host SSH signing key not loaded;
+- Docker agent bridge unavailable;
+- public-key snapshot failure;
+- selected identity missing in the container;
+- disposable signing failure;
+- GitHub signing registration missing;
+- GitHub registration check unavailable.
+
+Human-readable warnings state that commits will remain unsigned but are not
+blocked. A missing GitHub registration warning instead states that commits are
+signed locally but will not appear Verified on GitHub.
+
+## Testing Strategy
+
+### Unit tests
+
+- Resolve a host-configured SSH signing key that is loaded in the agent.
+- Resolve exactly one loaded key that matches GitHub authentication keys.
+- Resolve a single loaded key without GitHub access.
+- Disable signing for zero keys, multiple ambiguous keys, malformed keys, and
+  command or API failures.
+- Compare public keys without considering comments.
+- Generate Docker Desktop and native Linux socket mounts correctly.
+- Omit signing mounts and environment values for disabled plans.
+- Generate the signing public-key state mount as read-only.
+- Configure SSH signing after a successful container probe.
+- Fall back to unsigned global configuration after every validation failure.
+- Prove that post-create no longer writes repository-local
+  `commit.gpgsign`.
+- Report all signing preflight failures as warnings rather than failures.
+- Exercise `setup`, `start`, coding-agent, SSH proxy, and tunnel paths through
+  the shared signing lifecycle.
+
+### Shell-script tests
+
+Container signing bootstrap tests use temporary Git homes, repositories, fake
+agent output, and disposable public keys. They verify both the enabled Git
+configuration and the non-blocking unsigned fallback.
+
+### Docker integration test
+
+A gated manual or integration test mounts a real agent bridge into a disposable
+container, creates an empty signed commit, and verifies the signature and
+fingerprint. It is skipped when Docker or a usable agent identity is absent.
+It does not push a commit or change a GitHub account.
+
+### Manual acceptance
+
+Create a new Boxdown environment and verify signed commits from:
+
+- `boxdown start`;
+- `boxdown codex`;
+- an SSH session through the generated Boxdown alias.
+
+Push a test branch only when explicitly authorized, then verify GitHub's badge
+before and after registering the selected public key as a signing key.
+
+## Documentation
+
+Implementation updates will include:
+
+- a dedicated commit-signing feature document;
+- README behavior and security notes;
+- setup and doctor documentation;
+- architecture documentation for signing state, generated mounts, and trust
+  boundaries;
+- troubleshooting for ambiguity, absent agents, Docker mount failures,
+  unsigned fallback, and missing GitHub verification;
+- a changeset describing default-on best-effort signing.
+
+The documentation will explicitly state that multiple ambiguous agent keys
+disable signing rather than causing Boxdown to guess, and that this fallback
+allows unsigned commits.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ import {
 } from './constants.ts'
 import { parseJsonc } from './jsonc.ts'
 import type { WorkspaceContext } from './paths.ts'
+import type { GitSigningPlan } from './git-signing.ts'
 import { shellQuote } from './shell.ts'
 
 export interface DevcontainerConfig {
@@ -55,7 +56,7 @@ function hasMountTarget (mounts: string[], target: string): boolean {
   return mounts.some((mount) => mountHasTarget(mount, target))
 }
 
-export function buildGeneratedDevcontainerConfig (context: WorkspaceContext): DevcontainerConfig {
+export function buildGeneratedDevcontainerConfig (context: WorkspaceContext, signing?: GitSigningPlan): DevcontainerConfig {
   const baseConfig = readBaseDevcontainerConfig(context.assetsDevcontainerDir)
   const mounts = Array.isArray(baseConfig.mounts)
     ? baseConfig.mounts
@@ -74,6 +75,11 @@ export function buildGeneratedDevcontainerConfig (context: WorkspaceContext): De
     !hasMountTarget(mounts, BOXDOWN_CONTAINER_AGENTS_DIR)
   ) {
     boxdownMounts.push(`type=bind,source=${context.hostAgentsDir},target=${BOXDOWN_CONTAINER_AGENTS_DIR},readonly`)
+  }
+
+  if (signing?.enabled === true && signing.agentSocketSource !== undefined) {
+    boxdownMounts.push(`type=bind,source=${signing.agentSocketSource},target=/run/boxdown/ssh-agent.sock`)
+    boxdownMounts.push(`type=bind,source=${context.gitSigningStateDir},target=/opt/boxdown/state/git-signing,readonly`)
   }
 
   if (
@@ -113,13 +119,16 @@ export function buildGeneratedDevcontainerConfig (context: WorkspaceContext): De
       ...(baseConfig.containerEnv ?? {}),
       BOXDOWN_CONTAINER_WORKSPACE_FOLDER: '/workspaces/${localWorkspaceFolderBasename}',
       BOXDOWN_WORKSPACE_BASENAME: '${localWorkspaceFolderBasename}',
-      DEVCONTAINER_SSH_PUBLIC_KEY_FILE: BOXDOWN_CONTAINER_SSH_PUBLIC_KEY_PATH
+      DEVCONTAINER_SSH_PUBLIC_KEY_FILE: BOXDOWN_CONTAINER_SSH_PUBLIC_KEY_PATH,
+      BOXDOWN_GIT_SIGNING_ENABLED: signing?.enabled === true ? '1' : '0',
+      BOXDOWN_GIT_SIGNING_KEY_PATH: '/opt/boxdown/state/git-signing/signing-key.pub',
+      ...(signing?.enabled === true ? { SSH_AUTH_SOCK: '/run/boxdown/ssh-agent.sock' } : {})
     }
   }
 }
 
-export function writeGeneratedDevcontainerConfig (context: WorkspaceContext): DevcontainerConfig {
-  const config = buildGeneratedDevcontainerConfig(context)
+export function writeGeneratedDevcontainerConfig (context: WorkspaceContext, signing?: GitSigningPlan): DevcontainerConfig {
+  const config = buildGeneratedDevcontainerConfig(context, signing)
   mkdirSync(context.workspaceCacheDir, { recursive: true })
   writeFileSync(context.generatedConfigPath, `${JSON.stringify(config, null, 2)}\n`)
   return config

--- a/src/devcontainer.ts
+++ b/src/devcontainer.ts
@@ -5,6 +5,7 @@ import { buildGeneratedDevcontainerConfig, publishContainerPortFromConfig, write
 import { codingAgentBinary, type CodingAgentCli } from './coding-agents.ts'
 import { resolveDevcontainerCli } from './devcontainer-cli.ts'
 import { configureWorkspaceGithubGitAuth } from './github-git-auth.ts'
+import { resolveGitSigningPlan } from './git-signing.ts'
 import type { WorkspaceCommandLogger } from './logging.ts'
 import { recordWorkspaceDockerImage } from './metadata.ts'
 import type { WorkspaceContext } from './paths.ts'
@@ -319,7 +320,7 @@ export async function startDevcontainer (context: WorkspaceContext, options: Sta
     progress.detail(context.generatedConfigPath)
   }
   try {
-    writeGeneratedDevcontainerConfig(context)
+    writeGeneratedDevcontainerConfig(context, await resolveGitSigningPlan(context))
     if (hasConfigStep) {
       progress?.completeStep('devcontainer-config')
     }
@@ -668,7 +669,7 @@ export async function refreshContainerGhAuth (context: WorkspaceContext, options
       quiet: true,
       progress
     })
-    writeGeneratedDevcontainerConfig(context)
+    writeGeneratedDevcontainerConfig(context, await resolveGitSigningPlan(context))
     if (hasConfigStep) {
       progress?.completeStep('gh-auth-config')
     }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -69,6 +69,22 @@ export async function runDoctorChecks (context: WorkspaceContext, options: RunDo
     `Node ${nodeVersion}; expected >=24.0.0`
   ))
 
+  const sshAgent = await runCommand('ssh-add', ['-L'])
+  const identities = sshAgent.code === 0
+    ? sshAgent.stdout.split(/\r?\n/).filter((line) => line.trim().startsWith('ssh-')).length
+    : 0
+  checks.push({
+    name: 'git-signing-agent',
+    level: sshAgent.code === 0 && identities === 1 ? 'ok' : 'warn',
+    message: sshAgent.code !== 0
+      ? 'SSH agent is unavailable; Boxdown commits will remain unsigned'
+      : identities === 0
+        ? 'SSH agent has no identities; Boxdown commits will remain unsigned'
+        : identities > 1
+          ? 'SSH agent has multiple identities; Boxdown will not guess a signing key and commits will remain unsigned'
+          : 'One SSH agent identity is available for Boxdown commit signing'
+  })
+
   checks.push(check(
     'devcontainers-cli',
     await packagedDevcontainerCliWorks(context, runCommand),
@@ -125,6 +141,22 @@ export async function runDoctorChecks (context: WorkspaceContext, options: RunDo
         level: ghAuth ? 'ok' : 'warn',
         message: ghAuth ? 'GitHub CLI auth is available' : 'GitHub CLI is available but not authenticated'
       })
+      if (ghAuth && identities === 1) {
+        const user = await runCommand('gh', ['api', 'user', '--jq', '.login'])
+        const signing = user.code === 0 && user.stdout.trim().length > 0
+          ? await runCommand('gh', ['api', `users/${user.stdout.trim()}/ssh_signing_keys`, '--paginate', '--jq', '.[].key'])
+          : { code: 1, stdout: '', stderr: '' }
+        const identity = sshAgent.stdout.split(/\r?\n/).find((line) => line.trim().startsWith('ssh-'))?.trim()
+        checks.push({
+          name: 'git-signing-github',
+          level: signing.code === 0 && identity !== undefined && signing.stdout.includes(identity.split(/\s+/, 3).slice(0, 2).join(' ')) ? 'ok' : 'warn',
+          message: signing.code !== 0
+            ? 'GitHub SSH signing-key registration could not be checked'
+            : signing.stdout.includes(identity?.split(/\s+/, 3).slice(0, 2).join(' ') ?? '')
+              ? 'Selected SSH key is registered with GitHub for commit signing'
+              : 'Register the selected public key with GitHub as a signing key to receive Verified badges'
+        })
+      }
     } else {
       checks.push({
         name: 'gh',

--- a/src/git-signing.ts
+++ b/src/git-signing.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import type { WorkspaceContext } from './paths.ts'
+import { runBuffered } from './process.ts'
+
+export type GitSigningReason = 'agent-unavailable' | 'no-identities' | 'ambiguous-identities' | 'configured-key-not-loaded' | 'agent-mount-unavailable'
+
+export interface GitSigningPlan {
+  enabled: boolean
+  reason?: GitSigningReason
+  publicKey?: string
+  agentSocketSource?: string
+}
+
+export function parseSshPublicKey (value: string): string | undefined {
+  const [algorithm, key] = value.trim().split(/\s+/, 3)
+  if (algorithm === undefined || key === undefined || !/^ssh-[A-Za-z0-9-]+$/.test(algorithm) || key.length === 0) {
+    return undefined
+  }
+
+  return `${algorithm} ${key}`
+}
+
+export function selectGitSigningKey (identities: string[], configuredKey?: string, githubKeys?: string[]): { key?: string, reason?: GitSigningReason } {
+  const keys = identities.map(parseSshPublicKey).filter((key): key is string => key !== undefined)
+  if (keys.length === 0) return { reason: 'no-identities' }
+
+  const configured = configuredKey === undefined ? undefined : parseSshPublicKey(configuredKey)
+  if (configured !== undefined) {
+    return keys.includes(configured) ? { key: configured } : { reason: 'configured-key-not-loaded' }
+  }
+
+  const github = new Set((githubKeys ?? []).map(parseSshPublicKey).filter((key): key is string => key !== undefined))
+  const matches = keys.filter((key) => github.has(key))
+  if (matches.length === 1) return { key: matches[0] }
+  if (keys.length === 1) return { key: keys[0] }
+  return { reason: 'ambiguous-identities' }
+}
+
+export function writeGitSigningPublicKey (context: WorkspaceContext, key: string): void {
+  mkdirSync(context.gitSigningStateDir, { recursive: true, mode: 0o700 })
+  writeFileSync(join(context.gitSigningStateDir, 'signing-key.pub'), `${parseSshPublicKey(key) ?? key}\n`, { mode: 0o644 })
+}
+
+async function dockerCanMountAgent (source: string): Promise<boolean> {
+  const images = await runBuffered('docker', ['image', 'ls', '--format', '{{.Repository}}:{{.Tag}}'], { mirrorStdout: false, mirrorStderr: false })
+  const image = images.stdout.split(/\r?\n/).map((value) => value.trim()).find((value) => value.length > 0 && value !== '<none>:<none>')
+  if (images.code !== 0 || image === undefined) return false
+
+  const created = await runBuffered('docker', ['create', '--pull=never', '--entrypoint', '/bin/true', '--mount', `type=bind,source=${source},target=/run/boxdown/ssh-agent.sock`, image], { mirrorStdout: false, mirrorStderr: false })
+  const containerId = created.stdout.trim().split(/\r?\n/)[0]
+  if (created.code !== 0 || containerId === undefined || containerId.length === 0) return false
+  await runBuffered('docker', ['rm', '-f', containerId], { mirrorStdout: false, mirrorStderr: false })
+  return true
+}
+
+export async function resolveGitSigningPlan (context: WorkspaceContext): Promise<GitSigningPlan> {
+  const result = await runBuffered('ssh-add', ['-L'], { mirrorStdout: false, mirrorStderr: false })
+  if (result.code !== 0) return { enabled: false, reason: 'agent-unavailable' }
+
+  const identities = result.stdout.split(/\r?\n/)
+  const format = await runBuffered('git', ['config', '--global', '--get', 'gpg.format'], { mirrorStdout: false, mirrorStderr: false })
+  const configuredKey = format.code === 0 && format.stdout.trim() === 'ssh'
+    ? (await runBuffered('git', ['config', '--global', '--get', 'user.signingkey'], { mirrorStdout: false, mirrorStderr: false })).stdout.trim()
+    : undefined
+  let githubKeys: string[] | undefined
+  if (identities.filter((key) => parseSshPublicKey(key) !== undefined).length > 1) {
+    const user = await runBuffered('gh', ['api', 'user', '--jq', '.login'], { mirrorStdout: false, mirrorStderr: false })
+    const login = user.stdout.trim()
+    if (user.code === 0 && login.length > 0) {
+      const github = await runBuffered('gh', ['api', `users/${login}/keys`, '--paginate', '--jq', '.[].key'], { mirrorStdout: false, mirrorStderr: false })
+      if (github.code === 0) githubKeys = github.stdout.split(/\r?\n/)
+    }
+  }
+  const selected = selectGitSigningKey(identities, configuredKey, githubKeys)
+  if (selected.key === undefined) return { enabled: false, reason: selected.reason }
+
+  const agentSocketSource = process.platform === 'darwin'
+    ? '/run/host-services/ssh-auth.sock'
+    : process.env.SSH_AUTH_SOCK
+  if (agentSocketSource === undefined || agentSocketSource.length === 0) return { enabled: false, reason: 'agent-mount-unavailable' }
+  if (!await dockerCanMountAgent(agentSocketSource)) return { enabled: false, reason: 'agent-mount-unavailable' }
+
+  writeGitSigningPublicKey(context, selected.key)
+  return { enabled: true, publicKey: selected.key, agentSocketSource }
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -30,6 +30,8 @@ export interface WorkspaceContext {
   hostGitconfigPath: string
   hostGitconfigSnapshotDir: string
   hostGitconfigSnapshotPath: string
+  gitSigningStateDir: string
+  gitSigningPublicKeyPath: string
   sshKeyDir: string
   sshKeyPath: string
   sshPublicKeyPath: string
@@ -133,6 +135,8 @@ export function createWorkspaceContextFromIdentity (
     hostGitconfigPath: defaultHostGitconfigPath(env),
     hostGitconfigSnapshotDir,
     hostGitconfigSnapshotPath: join(hostGitconfigSnapshotDir, '.gitconfig'),
+    gitSigningStateDir: join(workspaceDataDir, 'git-signing'),
+    gitSigningPublicKeyPath: join(workspaceDataDir, 'git-signing', 'signing-key.pub'),
     sshKeyDir: join(workspaceDataDir, 'ssh'),
     sshKeyPath: join(workspaceDataDir, 'ssh', 'id_ed25519'),
     sshPublicKeyPath: join(workspaceDataDir, 'ssh', 'id_ed25519.pub'),


### PR DESCRIPTION
## Summary

Enable best-effort SSH commit signing in new Boxdown environments.

- Select an unambiguous host SSH identity, preferring the authenticated GitHub key.
- Mount Docker Desktop's SSH-agent bridge and snapshot only the selected public key.
- Configure Git for SSH signing after a disposable signing probe; otherwise keep commits unsigned with a warning.
- Add doctor guidance for agent readiness and GitHub signing-key registration.

## Validation

- node --import tsx --test __tests__/**/*.test.ts
- TypeScript, ESLint, Markdown lint, shell syntax, and diff checks
- Disposable Docker Desktop SSH-agent signing smoke test