### PR TITLE
feat: varlock credential proxy mode - keep secret values out of the container

### DIFF
--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -9420,6 +9420,130 @@ describe('devcontainer git config hooks', () => {
     assert.strictEqual(readFileSync(projectEnv, 'utf8'), 'PROJECT_VALUE=unchanged\n')
   })
 
+  test('initialization boots or reuses a varlock proxy session for schema workspaces and writes placeholder wiring', () => {
+    const initializePath = join(assetsDevcontainerDir, 'hooks', 'initialize.sh')
+    const binDir = join(tempDir('varlock-initialize-bin'), 'bin')
+    const workspace = tempDir('varlock-initialize-workspace')
+    const hostCaDir = tempDir('varlock-initialize-host-ca')
+    const stateDir = tempDir('varlock-initialize-stub-state')
+    const secretDir = join(tempDir('varlock-initialize-state'), 'secrets')
+    const argsLog = join(tempDir('varlock-initialize-log'), 'args.log')
+    mkdirSync(binDir)
+    mkdirSync(secretDir, { recursive: true })
+    writeFileSync(join(workspace, '.env.schema'), '# @sensitive\nDEMO_TOKEN=\n')
+    writeFileSync(join(hostCaDir, 'ca-cert.pem'), 'proxy-ca-sentinel')
+    writeFileSync(join(hostCaDir, 'combined-ca.pem'), 'combined-ca-sentinel')
+    writeFileSync(join(binDir, 'op'), '#!/usr/bin/env bash\nexit 1\n')
+    chmodSync(join(binDir, 'op'), 0o755)
+    writeFileSync(join(binDir, 'varlock'), [
+      '#!/usr/bin/env bash',
+      'printf \'%s\\n\' "$*" >> "${VARLOCK_STUB_ARGS_LOG}"',
+      '[[ "${VARLOCK_STUB_MODE:-ok}" == "fail" ]] && exit 1',
+      'if [[ "$1" == "proxy" && "$2" == "status" ]]; then',
+      '  if [[ -f "${VARLOCK_STUB_STATE_DIR}/started" ]]; then',
+      '    printf \'[{"id":"stub-session","cwd":"%s"}]\\n\' "${VARLOCK_STUB_WORKSPACE}"',
+      '  else',
+      '    printf \'[]\\n\'',
+      '  fi',
+      'elif [[ "$1" == "proxy" && "$2" == "start" ]]; then',
+      '  touch "${VARLOCK_STUB_STATE_DIR}/started"',
+      'elif [[ "$*" == *"--proxy-url"* ]]; then',
+      '  guest_url=""; cert_dir=""; previous=""',
+      '  for argument in "$@"; do',
+      '    [[ "${previous}" == "--proxy-url" ]] && guest_url="${argument}"',
+      '    [[ "${previous}" == "--cert-dir" ]] && cert_dir="${argument}"',
+      '    previous="${argument}"',
+      '  done',
+      '  printf "export HTTPS_PROXY=\'%s\'\\n" "${guest_url}"',
+      '  printf "export SSL_CERT_FILE=\'%s/combined-ca.pem\'\\n" "${cert_dir}"',
+      '  printf "export DEMO_TOKEN=\'DEMO-PLACEHOLDER\'\\n"',
+      'else',
+      '  printf "export HTTPS_PROXY=\'http://127.0.0.1:59999\'\\n"',
+      '  printf "export SSL_CERT_FILE=\'%s/combined-ca.pem\'\\n" "${VARLOCK_STUB_CA_DIR}"',
+      'fi',
+      ''
+    ].join('\n'))
+    chmodSync(join(binDir, 'varlock'), 0o755)
+    writeFileSync(join(secretDir, 'ANTHROPIC_API_KEY'), 'stale-anthropic-runtime-sentinel')
+
+    const baseEnv = {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+      BOXDOWN_WORKSPACE_FOLDER: workspace,
+      BOXDOWN_SECRET_ENV_DIR: secretDir,
+      VARLOCK_STUB_ARGS_LOG: argsLog,
+      VARLOCK_STUB_CA_DIR: hostCaDir,
+      VARLOCK_STUB_STATE_DIR: stateDir,
+      VARLOCK_STUB_WORKSPACE: workspace,
+      ANTHROPIC_API_KEY: 'anthropic-runtime-sentinel'
+    }
+
+    // no session running: initialization boots one, then wires the container
+    execFileSync('bash', [initializePath], { env: baseEnv })
+
+    const guestEnv = readFileSync(join(secretDir, 'varlock.env'), 'utf8')
+    assert.match(guestEnv, /HTTPS_PROXY='http:\/\/host\.docker\.internal:59999'/)
+    assert.match(guestEnv, /SSL_CERT_FILE='\/run\/boxdown\/secrets\/varlock-ca\/combined-ca\.pem'/)
+    assert.match(guestEnv, /DEMO_TOKEN='DEMO-PLACEHOLDER'/)
+    assert.strictEqual(statSync(join(secretDir, 'varlock.env')).mode & 0o777, 0o600)
+    assert.strictEqual(readFileSync(join(secretDir, 'varlock-ca', 'ca-cert.pem'), 'utf8'), 'proxy-ca-sentinel')
+    assert.strictEqual(readFileSync(join(secretDir, 'varlock-ca', 'combined-ca.pem'), 'utf8'), 'combined-ca-sentinel')
+    assert.strictEqual(existsSync(join(secretDir, 'ANTHROPIC_API_KEY')), false)
+    assert.match(readFileSync(argsLog, 'utf8'), /^proxy start$/m)
+    assert.match(readFileSync(argsLog, 'utf8'), /--session stub-session/)
+
+    // session now registered: a re-run reuses it instead of starting another
+    rmSync(argsLog)
+    execFileSync('bash', [initializePath], { env: baseEnv })
+    assert.doesNotMatch(readFileSync(argsLog, 'utf8'), /^proxy start$/m)
+    assert.match(readFileSync(argsLog, 'utf8'), /--session stub-session/)
+
+    // a workspace-local node_modules/.bin/varlock is preferred over PATH
+    rmSync(argsLog)
+    const localBinDir = join(workspace, 'node_modules', '.bin')
+    mkdirSync(localBinDir, { recursive: true })
+    writeFileSync(
+      join(localBinDir, 'varlock'),
+      readFileSync(join(binDir, 'varlock'), 'utf8').replace("printf '%s\\n'", "printf 'local %s\\n'")
+    )
+    chmodSync(join(localBinDir, 'varlock'), 0o755)
+    execFileSync('bash', [initializePath], { env: baseEnv })
+    assert.match(readFileSync(argsLog, 'utf8'), /^local proxy status/m)
+    assert.doesNotMatch(readFileSync(argsLog, 'utf8'), /^proxy status/m)
+    rmSync(join(workspace, 'node_modules'), { recursive: true, force: true })
+
+    // explicit session selection bypasses workspace lookup
+    rmSync(argsLog)
+    execFileSync('bash', [initializePath], {
+      env: { ...baseEnv, BOXDOWN_VARLOCK_PROXY_SESSION: 'explicit-session' }
+    })
+    assert.match(readFileSync(argsLog, 'utf8'), /--session explicit-session/)
+
+    // a workspace without .env.schema keeps the plaintext secret-file behavior
+    const plainWorkspace = tempDir('varlock-initialize-plain-workspace')
+    execFileSync('bash', [initializePath], {
+      env: { ...baseEnv, BOXDOWN_WORKSPACE_FOLDER: plainWorkspace }
+    })
+    assert.strictEqual(existsSync(join(secretDir, 'varlock.env')), false)
+    assert.strictEqual(existsSync(join(secretDir, 'varlock-ca')), false)
+    assert.strictEqual(readFileSync(join(secretDir, 'ANTHROPIC_API_KEY'), 'utf8'), 'anthropic-runtime-sentinel')
+
+    // a failing varlock CLI falls back non-blocking after the boot timeout
+    rmSync(join(stateDir, 'started'))
+    execFileSync('bash', [initializePath], {
+      env: { ...baseEnv, VARLOCK_STUB_MODE: 'fail', BOXDOWN_VARLOCK_BOOT_TIMEOUT_SECONDS: '1' }
+    })
+    assert.strictEqual(existsSync(join(secretDir, 'varlock.env')), false)
+    assert.strictEqual(readFileSync(join(secretDir, 'ANTHROPIC_API_KEY'), 'utf8'), 'anthropic-runtime-sentinel')
+
+    // BOXDOWN_VARLOCK=0 disables detection entirely
+    execFileSync('bash', [initializePath], {
+      env: { ...baseEnv, BOXDOWN_VARLOCK: '0' }
+    })
+    assert.strictEqual(existsSync(join(secretDir, 'varlock.env')), false)
+    assert.strictEqual(readFileSync(join(secretDir, 'ANTHROPIC_API_KEY'), 'utf8'), 'anthropic-runtime-sentinel')
+  })
+
   test('initialize snapshots host gitconfig and removes stale snapshot when host file is absent', () => {
     const initializePath = join(assetsDevcontainerDir, 'hooks', 'initialize.sh')
     const workspace = tempDir('initialize-gitconfig-workspace')
@@ -9715,6 +9839,37 @@ describe('interactive shell setup', () => {
     assert.match(result.stdout, /^snyk:yes$/m)
     assert.match(result.stdout, /^op:no$/m)
     assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /bootstrap-sentinel/)
+  })
+
+  test('sources varlock proxy wiring when present without outputting values', () => {
+    const bootstrapEnvWithoutSecrets = () => {
+      const env = { ...process.env }
+      delete env.ANTHROPIC_API_KEY
+      delete env.DEMO_TOKEN
+      delete env.HTTPS_PROXY
+      return env
+    }
+    const bootstrapPath = join(assetsDevcontainerDir, 'utils', 'secret-env-bootstrap.sh')
+    const secretDir = tempDir('varlock-bootstrap')
+    writeFileSync(join(secretDir, 'varlock.env'), [
+      "export DEMO_TOKEN='DEMO-PLACEHOLDER'",
+      "export HTTPS_PROXY='http://host.docker.internal:59999'",
+      ''
+    ].join('\n'))
+    const result = spawnSync('bash', [
+      '-c',
+      'source "$1"; [[ "${DEMO_TOKEN:-}" == "DEMO-PLACEHOLDER" ]] && echo demo:yes; [[ "${HTTPS_PROXY:-}" == "http://host.docker.internal:59999" ]] && echo proxy:yes; [[ -z "${ANTHROPIC_API_KEY:-}" ]] && echo anthropic:no',
+      'bash',
+      bootstrapPath
+    ], {
+      encoding: 'utf8',
+      env: { ...bootstrapEnvWithoutSecrets(), BOXDOWN_SECRET_ENV_DIR: secretDir }
+    })
+
+    assert.strictEqual(result.status, 0)
+    assert.match(result.stdout, /^demo:yes$/m)
+    assert.match(result.stdout, /^proxy:yes$/m)
+    assert.match(result.stdout, /^anthropic:no$/m)
   })
 
   test('defaults to conservative TTY width normalization', () => {

--- a/assets/devcontainer/devcontainer.json
+++ b/assets/devcontainer/devcontainer.json
@@ -53,7 +53,10 @@
     "runArgs": [
         // publish container port 3000 with dynamic host port (CLI / start.sh)
         "-p",
-        "127.0.0.1::3000"
+        "127.0.0.1::3000",
+        // make the host reachable as host.docker.internal on Linux engines too
+        // (Docker Desktop resolves it natively); used by varlock proxy mode
+        "--add-host=host.docker.internal:host-gateway"
     ],
     // --
     "postCreateCommand": "bash .devcontainer/hooks/post-create.sh",

--- a/assets/devcontainer/hooks/initialize.sh
+++ b/assets/devcontainer/hooks/initialize.sh
@@ -8,6 +8,12 @@ HOST_GITCONFIG_PATH="${BOXDOWN_HOST_GITCONFIG_PATH:-${HOME:-}/.gitconfig}"
 HOST_GITCONFIG_SNAPSHOT_PATH="${BOXDOWN_HOST_GITCONFIG_SNAPSHOT_PATH:-}"
 SECRET_ENV_DIR="${BOXDOWN_SECRET_ENV_DIR:-}"
 OP_TOKEN_REFERENCE="op://Private/1Password op CLI Service Account for DevContainers/password"
+WORKSPACE_FOLDER="${BOXDOWN_WORKSPACE_FOLDER:-}"
+VARLOCK_BIN=""
+VARLOCK_GUEST_PROXY_HOST="${BOXDOWN_VARLOCK_PROXY_HOST:-host.docker.internal}"
+# Container-side view of SECRET_ENV_DIR (mount target in generated config).
+VARLOCK_CONTAINER_CA_DIR="/run/boxdown/secrets/varlock-ca"
+VARLOCK_PROXY_SESSION="${BOXDOWN_VARLOCK_PROXY_SESSION:-}"
 
 main() {
   progress "Snapshotting host Git config"
@@ -96,8 +102,169 @@ refresh_1password_service_account_token() {
   write_secret_file "OP_SERVICE_ACCOUNT_TOKEN" "${token}"
 }
 
+remove_varlock_proxy_files() {
+  rm -f "${SECRET_ENV_DIR}/varlock.env"
+  rm -rf "${SECRET_ENV_DIR}/varlock-ca"
+}
+
+# Prefer the workspace's own varlock install (a project devDependency pins the
+# version) and fall back to a global install on PATH.
+resolve_varlock_bin() {
+  if [[ -n "${WORKSPACE_FOLDER}" && -x "${WORKSPACE_FOLDER}/node_modules/.bin/varlock" ]]; then
+    VARLOCK_BIN="${WORKSPACE_FOLDER}/node_modules/.bin/varlock"
+    return 0
+  fi
+  if command -v varlock >/dev/null 2>&1; then
+    VARLOCK_BIN="varlock"
+    return 0
+  fi
+  return 1
+}
+
+# Find the id of the active proxy session started from the workspace folder.
+# Boxdown requires Node on the host, so `node` is a safe JSON parser here.
+find_varlock_session_for_workspace() {
+  "${VARLOCK_BIN}" proxy status --format json 2>/dev/null | node -e '
+    let raw = "";
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      try {
+        const sessions = JSON.parse(raw);
+        const match = sessions.find((session) => session.cwd === process.argv[1]);
+        if (match) process.stdout.write(match.id);
+      } catch {}
+    });
+  ' "${WORKSPACE_FOLDER}"
+}
+
+# Start a proxy daemon for the workspace. Fully detached from this hook's
+# stdio: without that, a lingering intermediate shell can hold a pipe open and
+# block the hook (or the Dev Container CLI capturing its output) forever. The
+# daemon outlives this hook; its log stays in the workspace runtime directory
+# (outside the container mount).
+start_varlock_proxy_daemon() {
+  local log_path
+
+  log_path="$(dirname "${SECRET_ENV_DIR}")/varlock-proxy-start.log"
+  (cd "${WORKSPACE_FOLDER}" \
+    && nohup "${VARLOCK_BIN}" proxy start >> "${log_path}" 2>&1 < /dev/null &) > /dev/null 2>&1
+}
+
+# Wait for the booted daemon's session to register, setting
+# VARLOCK_PROXY_SESSION. Booting can take a moment when the schema resolves
+# values from a secrets manager (a 1Password biometric prompt, for example),
+# so the wait allows for that.
+wait_for_varlock_session() {
+  local attempt
+
+  for attempt in $(seq 1 $(( ${BOXDOWN_VARLOCK_BOOT_TIMEOUT_SECONDS:-30} * 2 ))); do
+    VARLOCK_PROXY_SESSION="$(find_varlock_session_for_workspace)"
+    if [[ -n "${VARLOCK_PROXY_SESSION}" ]]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+varlock_proxy_env() {
+  "${VARLOCK_BIN}" proxy env --session "${VARLOCK_PROXY_SESSION}" "$@" 2>/dev/null
+}
+
+# When the workspace has a varlock schema (.env.schema), container sessions get
+# placeholder values plus proxy/CA wiring instead of real secrets. Real values
+# then never enter the container; the credential proxy substitutes them at the
+# network boundary on the host. Reuses the workspace's running proxy session or
+# boots one. Returns non-zero (without failing the hook) when varlock is
+# unavailable or the proxy cannot start, so the plaintext secret-file path
+# below remains the fallback.
+refresh_varlock_proxy_environment() {
+  local wiring proxy_url proxy_port host_ca_path host_ca_dir
+  local guest_env temporary_path guest_ca_dir
+
+  if [[ "${BOXDOWN_VARLOCK:-1}" == "0" ]]; then
+    remove_varlock_proxy_files
+    return 1
+  fi
+
+  if [[ -z "${WORKSPACE_FOLDER}" || ! -f "${WORKSPACE_FOLDER}/.env.schema" ]]; then
+    remove_varlock_proxy_files
+    return 1
+  fi
+
+  if ! resolve_varlock_bin; then
+    echo "initialize.sh: workspace has a .env.schema but varlock is not installed; using plaintext secret files. Install varlock (npm i varlock, or npm i -g varlock) to keep secrets out of the container." >&2
+    remove_varlock_proxy_files
+    return 1
+  fi
+
+  if [[ -z "${VARLOCK_PROXY_SESSION}" ]]; then
+    VARLOCK_PROXY_SESSION="$(find_varlock_session_for_workspace)"
+  fi
+  if [[ -z "${VARLOCK_PROXY_SESSION}" ]]; then
+    progress "Starting varlock credential proxy for this workspace"
+    start_varlock_proxy_daemon
+    if ! wait_for_varlock_session; then
+      echo "initialize.sh: could not start a varlock proxy session; falling back to plaintext secret files. Check $(dirname "${SECRET_ENV_DIR}")/varlock-proxy-start.log" >&2
+      remove_varlock_proxy_files
+      return 1
+    fi
+  fi
+
+  if ! wiring="$(varlock_proxy_env --format shell)"; then
+    remove_varlock_proxy_files
+    return 1
+  fi
+
+  # The session's own wiring is loopback-relative. Extract the port and the
+  # host-side CA bundle directory, then re-request the env repointed for the
+  # container: proxy vars at host.docker.internal, CA vars at the mounted dir.
+  proxy_url="$(printf '%s\n' "${wiring}" | sed -n "s/^export HTTPS_PROXY=['\"]\{0,1\}\([^'\"]*\).*/\1/p" | head -n 1)"
+  proxy_url="${proxy_url%/}"
+  proxy_port="${proxy_url##*:}"
+  host_ca_path="$(printf '%s\n' "${wiring}" | sed -n "s/^export SSL_CERT_FILE=['\"]\{0,1\}\([^'\"]*\).*/\1/p" | head -n 1)"
+  if [[ -z "${proxy_port}" || -z "${host_ca_path}" || ! -r "${host_ca_path}" ]]; then
+    echo "initialize.sh: varlock proxy session found but its wiring env was incomplete; falling back to plaintext secret files." >&2
+    remove_varlock_proxy_files
+    return 1
+  fi
+  host_ca_dir="$(dirname "${host_ca_path}")"
+  if [[ ! -r "${host_ca_dir}/ca-cert.pem" || ! -r "${host_ca_dir}/combined-ca.pem" ]]; then
+    echo "initialize.sh: varlock proxy CA bundle is missing from ${host_ca_dir}; falling back to plaintext secret files." >&2
+    remove_varlock_proxy_files
+    return 1
+  fi
+
+  if ! guest_env="$(varlock_proxy_env \
+    --proxy-url "http://${VARLOCK_GUEST_PROXY_HOST}:${proxy_port}" \
+    --cert-dir "${VARLOCK_CONTAINER_CA_DIR}" \
+    --format shell)"; then
+    remove_varlock_proxy_files
+    return 1
+  fi
+
+  guest_ca_dir="${SECRET_ENV_DIR}/varlock-ca"
+  mkdir -p "${guest_ca_dir}"
+  chmod 0700 "${guest_ca_dir}"
+  cp "${host_ca_dir}/ca-cert.pem" "${host_ca_dir}/combined-ca.pem" "${guest_ca_dir}/"
+  chmod 0600 "${guest_ca_dir}/ca-cert.pem" "${guest_ca_dir}/combined-ca.pem"
+
+  temporary_path="$(mktemp "${SECRET_ENV_DIR}/.varlock.env.XXXXXX")"
+  printf '%s\n' "${guest_env}" > "${temporary_path}"
+  chmod 0600 "${temporary_path}"
+  mv -f "${temporary_path}" "${SECRET_ENV_DIR}/varlock.env"
+}
+
 refresh_runtime_secret_environment() {
   if ! prepare_secret_env_dir; then
+    return 0
+  fi
+
+  if refresh_varlock_proxy_environment; then
+    progress "Varlock proxy session detected; container gets placeholders only"
+    rm -f "${SECRET_ENV_DIR}/ANTHROPIC_API_KEY" \
+      "${SECRET_ENV_DIR}/SNYK_TOKEN" \
+      "${SECRET_ENV_DIR}/OP_SERVICE_ACCOUNT_TOKEN"
     return 0
   fi
 

--- a/assets/devcontainer/utils/secret-env-bootstrap.sh
+++ b/assets/devcontainer/utils/secret-env-bootstrap.sh
@@ -16,6 +16,14 @@ export_if_present() {
   fi
 }
 
+# When the host runs a varlock credential proxy, this file carries placeholder
+# values plus HTTP(S)_PROXY and CA-bundle wiring instead of real secrets. The
+# plaintext per-secret files below are then absent by construction.
+if [[ -r "${SECRET_ENV_DIR}/varlock.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${SECRET_ENV_DIR}/varlock.env"
+fi
+
 export_if_present ANTHROPIC_API_KEY
 export_if_present SNYK_TOKEN
 export_if_present OP_SERVICE_ACCOUNT_TOKEN

--- a/docs/features/generated-config-and-state.md
+++ b/docs/features/generated-config-and-state.md
@@ -76,6 +76,34 @@ host values and failed 1Password lookup are non-blocking. `boxdown down` and
 `boxdown purge` remove the workspace runtime directory after container removal.
 Boxdown does not use or modify project `.env.development` files.
 
+### Varlock credential proxy mode
+
+When the workspace has a `.env.schema` and [varlock](https://varlock.dev) is
+installed (the workspace's `node_modules/.bin/varlock` is preferred, then a
+global install on `PATH`), initialization routes secrets through varlock's
+credential proxy instead of writing plaintext secret files. It reuses the
+workspace's running `varlock proxy` session or boots one (headless, with
+schema reload disabled), then writes proxy wiring into the runtime-secret
+directory: a sourceable `varlock.env` (placeholder values plus `HTTP(S)_PROXY`
+and CA-bundle variables pointing at the host proxy through
+`host.docker.internal`) and a `varlock-ca/` directory with the proxy CA
+certificates. Real secret values then never enter the container; the proxy
+substitutes them at the network boundary on the host and scrubs them from
+responses. The per-secret plaintext files are removed in this mode.
+
+Because varlock resolves values on the host, the schema can pull secrets from
+any varlock plugin (1Password, Bitwarden, AWS Secrets Manager, HashiCorp
+Vault, Doppler, and others) or varlock's built-in local encryption, without
+those managers' tokens entering the container.
+
+Set `BOXDOWN_VARLOCK=0` to skip proxy detection,
+`BOXDOWN_VARLOCK_PROXY_SESSION=<id>` to select a specific session, and
+`BOXDOWN_VARLOCK_BOOT_TIMEOUT_SECONDS` (default 30) to bound the boot wait.
+The booted daemon logs to `varlock-proxy-start.log` in the workspace runtime
+directory and keeps running after `boxdown down`; stop it with plain `kill`
+using the PID from `varlock proxy status`. When varlock is absent or the
+proxy cannot start, behavior falls back to plaintext secret files.
+
 ## Agent profile staging and authentication
 
 Only `auth` agent-profile sources are mounted at a read-only staging path below


### PR DESCRIPTION
This is a working proposal, offered in the "here's how it could look" spirit. Feel free to toss it, reshape it, or take just the ideas.

## What this does

Boxdown's runtime-secret design intentionally trades strictness for compatibility: `ANTHROPIC_API_KEY`, `SNYK_TOKEN`, and the 1Password service-account token are real values, readable by every process in the container. The decision record in `docs/superpowers/specs/2026-07-17-runtime-secret-environment-design.md` already anticipates a stricter model as a possible future step.

This PR adds that stricter model using [varlock](https://varlock.dev)'s credential proxy, while keeping the exact same developer experience (ordinary env vars in every Bash session):

- If the workspace has a `.env.schema` and the host has `varlock` installed, `initialize.sh` reuses the workspace's running `varlock proxy` session, or boots one headlessly. It then writes proxy wiring into the runtime-secret directory instead of plaintext secret files: a sourceable `varlock.env` (placeholder values plus `HTTP(S)_PROXY` and CA-bundle vars pointing at the host proxy via `host.docker.internal`) and the proxy's CA certificates.
- `secret-env-bootstrap.sh` sources that file when present, so every session (interactive, SSH, coding agents) gets placeholders and proxy wiring through the existing `BASH_ENV` path.
- Real values never enter the container. When a process calls an API the schema allows, the proxy swaps the placeholder for the real value on the wire (after verifying the upstream's TLS identity), and scrubs real values out of responses. Everything else the placeholder touches (env dumps, logs, exfil attempts) is useless.
- No `.env.schema`, no varlock on the host, boot failure, or `BOXDOWN_VARLOCK=0`: behavior is exactly as today, non-blocking.

The 1Password angle: with this model the `OP_SERVICE_ACCOUNT_TOKEN` doesn't need to enter the container at all. varlock's [1Password plugin](https://varlock.dev/plugins/1password/) resolves items on the host (through the desktop app with biometric auth, or a service account), and the container only ever sees placeholders. And because resolution is a host-side varlock concern, the same setup works with any of varlock's plugins (Bitwarden, AWS Secrets Manager, HashiCorp Vault, Doppler, Infisical, cloud keychains, ...) or its built-in local encryption, without teaching Boxdown anything about each manager.

## Trying it

```
npm i -D varlock      # or npm i -g varlock; the workspace copy is preferred
```

In a project, add a `.env.schema` (or run `varlock init`):

```
# @plugin(@varlock/1password-plugin)
# @initOp(allowAppAuth=true)
# ---

# @sensitive @proxy(domain="api.anthropic.com")
# @placeholder=sk-ant-api03-placeholder00000000
ANTHROPIC_API_KEY=op(op://Private/Anthropic/credential)

# @sensitive @proxy(domain="api.snyk.io")
SNYK_TOKEN=op(op://Private/Snyk/credential)
```

Then just:

```
boxdown setup        # or start --recreate for an existing workspace
```

Boxdown boots the proxy for you (a 1Password biometric prompt appears if the schema needs it). Running `varlock proxy start` yourself in a terminal first also works, and gives you the live request log and schema hot-reload; the hook attaches to it instead of booting a second one.

Verified end to end on macOS / Docker Desktop with this branch:

```
$ docker exec -u node <container> bash -c 'echo $ANTHROPIC_API_KEY; ls /run/boxdown/secrets'
sk-ant-api03-boxdownplaceholder00000000
varlock-ca
varlock.env

$ docker exec -u node <container> bash -c 'curl -s https://httpbin.org/headers -H "Authorization: Bearer $DEMO_TOKEN"'
    "Authorization": "Bearer DEMO-PLACEHOLDER-0000000000",   <- scrubbed even in the echo

# host-side audit log:
18:47:25 allow  GET   httpbin.org/headers           injected=DEMO_TOKEN        rule="httpbin.org"
17:04:14 allow  POST  api.anthropic.com/v1/messages injected=ANTHROPIC_API_KEY rule="api.anthropic.com"
```

The request to httpbin carried the real value; the container only ever held the placeholder, including in the echoed response body.

## Changes

- `assets/devcontainer/hooks/initialize.sh`: schema-gated varlock mode; resolves varlock from the workspace's `node_modules/.bin` first (a project devDependency pins the version), then PATH; finds the workspace's proxy session (or boots one, fully detached, logging to the workspace runtime dir) and writes `varlock.env` + `varlock-ca/`, removing the plaintext per-secret files. All failures fall back to current behavior, non-blocking.
- `assets/devcontainer/utils/secret-env-bootstrap.sh`: sources `varlock.env` when present.
- `assets/devcontainer/devcontainer.json`: adds `--add-host=host.docker.internal:host-gateway` so the name also resolves on Linux engines (Docker Desktop resolves it natively).
- Tests mirroring the existing initialize/bootstrap tests (stubbed `varlock` on PATH covering boot, reuse, explicit-session, no-schema, failure, and disable paths), plus a docs section in `docs/features/generated-config-and-state.md`.

Env knobs: `BOXDOWN_VARLOCK=0` disables detection; `BOXDOWN_VARLOCK_PROXY_SESSION=<id>` picks a specific session; `BOXDOWN_VARLOCK_BOOT_TIMEOUT_SECONDS` (default 30) bounds the boot wait.

## Limitations / honest notes

- varlock's proxy is in preview; flags may change in minor releases.
- On Linux hosts the proxy currently binds loopback, which `host-gateway` can't reach; Docker Desktop (macOS/Windows) is the path this was verified on.
- The booted daemon outlives `boxdown down` (sessions are cheap and reused); stopping it is a manual `kill` for now. A tidy lifecycle hook would be a follow-up.
- The staged Claude/Codex agent-profile credential files are out of scope here; those are real credentials in the container today. There's a follow-up story for Claude subscription auth via an `ANTHROPIC_AUTH_TOKEN` placeholder (no credential file needed in the container), happy to discuss.
- Tools that ignore `HTTP(S)_PROXY` or can't trust a custom CA would bypass/break; everything Boxdown ships (curl, git, npm, node, Claude Code, Snyk) cooperates.
